### PR TITLE
Fix icon downloading

### DIFF
--- a/ConsoleTester/Program.cs
+++ b/ConsoleTester/Program.cs
@@ -19,16 +19,18 @@ namespace ConsoleApplication1
 
 			main.Init(null);
 			var results = main.Query(query);
-
+            main.Steam.Load();
 			Console.WriteLine("Libraries: " + main.Steam.Libraries.Count);
 			Console.WriteLine("Games: " + main.Steam.Games.Count);
 			Console.WriteLine("Results: ");
-			foreach (var result in results)
-			{
-				Console.WriteLine(result.Title);
-			}
 
-			Console.ReadKey();
+            foreach(var game in main.Steam.Games)
+            {
+                Console.WriteLine(game.Name);
+                Console.WriteLine(game.Icon);
+            }
+
+            Console.ReadKey();
 		}
 	}
 }

--- a/WoxSteam/BinaryVdf/Reader.cs
+++ b/WoxSteam/BinaryVdf/Reader.cs
@@ -15,7 +15,7 @@ namespace WoxSteam.BinaryVdf
 
 		public Reader(string path)
 		{
-			reader = new BinaryReader(File.OpenRead(path));
+			reader = new BinaryReader(File.OpenRead(path), System.Text.Encoding.UTF8);
 
 			// Read some header fields
 			reader.ReadByte();
@@ -73,18 +73,18 @@ namespace WoxSteam.BinaryVdf
 
 		private string ReadString()
 		{
-			var result = "";
+            var result = new List<byte>();
 
-			// Read chars until null
-			while (reader.PeekChar() != 0x00)
-			{
-				result += reader.ReadChar();
-			}
+            while (reader.ReadByte() != 0x00)
+            {
+                reader.BaseStream.Position -= 1;
+                byte b = reader.ReadByte();
+                result.Add(b);
+            }
 
-			// Skip null
-			reader.ReadByte();
+            string yourText = System.Text.Encoding.UTF8.GetString(result.ToArray());
 
-			return result;
+            return yourText;
 		}
 
 
@@ -107,7 +107,18 @@ namespace WoxSteam.BinaryVdf
 
 		public BinaryVdfItem this[string index]
 		{
-			get { return Items[index]; }
+			get
+            {
+                if (Items.ContainsKey(index)) {
+                    return Items[index];
+
+                } else
+                {
+                    return new BinaryVdfItem();
+
+                }
+
+            }
 			set { Items[index] = value; }
 		}
 

--- a/WoxSteam/Game.cs
+++ b/WoxSteam/Game.cs
@@ -54,7 +54,7 @@ namespace WoxSteam
 		private string LoadIcon()
 		{
 			if (Details == null) return null;
-
+            if (Details.GetString("clienticon") == null) return null;
 			var icon = Details.GetString("clienticon") + ".ico";
 			var cachePath = Path.Combine(resourcesPath, icon);
 

--- a/WoxSteam/Steam.cs
+++ b/WoxSteam/Steam.cs
@@ -153,7 +153,7 @@ namespace WoxSteam
 					AppInfo = JsonConvert.DeserializeObject<Dictionary<uint, BinaryVdfItem>>(File.ReadAllText(cache));
 				}
 			}
-			catch (Exception)
+			catch (Exception e)
 			{
 				// Failed to load appinfo, but we can still display games, so deploy dummy appinfo
 				AppInfo = null;


### PR DESCRIPTION
Fixes icon downloading. 

c# is not my specialty, but this solution works. BinaryReader was throwing exceptions when reading with PeekChar and GetChar, so this solution uses ReadByte and constructs the string seperately.

Also some small changes to handle apps that dont have icons (instead of throwing exceptions it returns an empty VDF instance)