### PR TITLE
Custom class AppInfo is cached instead of BinaryVdfItem which speeds up the caching process

### DIFF
--- a/ConsoleTester/Program.cs
+++ b/ConsoleTester/Program.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Wox.Plugin;
-using WoxSteam;
 
 namespace ConsoleApplication1
 {
@@ -8,8 +6,8 @@ namespace ConsoleApplication1
     {
         public static void Main()
         {
-            var main = new Main();
-            var query = new Query();
+            var main = new WoxSteam.Main();
+            var query = new Wox.Plugin.Query();
 
             query.GetType().GetProperty("RawQuery")?.SetValue(query, "Arm", null);
             query.GetType().GetProperty("Search")?.SetValue(query, "Search", null);

--- a/ConsoleTester/Program.cs
+++ b/ConsoleTester/Program.cs
@@ -1,36 +1,30 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Wox.Plugin;
 using WoxSteam;
 
 namespace ConsoleApplication1
 {
-	public class Program
-	{
-		public static void Main(string[] args)
-		{
-			var main = new WoxSteam.Main();
-			var query = new Query();
+    public static class Program
+    {
+        public static void Main()
+        {
+            var main = new Main();
+            var query = new Query();
 
-			query.GetType().GetProperty("RawQuery").SetValue(query, "Arm", null);
-			query.GetType().GetProperty("Search").SetValue(query, "Search", null);
+            query.GetType().GetProperty("RawQuery")?.SetValue(query, "Arm", null);
+            query.GetType().GetProperty("Search")?.SetValue(query, "Search", null);
 
-			main.Init(null);
-			var results = main.Query(query);
-            main.Steam.Load();
-			Console.WriteLine("Libraries: " + main.Steam.Libraries.Count);
-			Console.WriteLine("Games: " + main.Steam.Games.Count);
-			Console.WriteLine("Results: ");
+            main.Init(null);
+            main.Query(query);
+            Console.WriteLine("Libraries: " + main.Steam.Libraries.Count);
+            Console.WriteLine("Games: " + main.Steam.Games.Count);
+            Console.WriteLine("Results: ");
 
-            foreach(var game in main.Steam.Games)
+            foreach (var game in main.Steam.Games)
             {
                 Console.WriteLine(game.Name);
                 Console.WriteLine(game.Icon);
             }
-
-            Console.ReadKey();
-		}
-	}
+        }
+    }
 }

--- a/ConsoleTester/Properties/AssemblyInfo.cs
+++ b/ConsoleTester/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/NeXt.Vdf-master/CharacterType.cs
+++ b/NeXt.Vdf-master/CharacterType.cs
@@ -1,0 +1,14 @@
+namespace NeXt.Vdf
+{
+    internal enum CharacterType
+    {
+        Whitespace,
+        Newline,
+        SequenceDelimiter,
+        CommentDelimiter,
+        TableOpen,
+        TableClose,
+        EscapeChar,
+        Char
+    }
+}

--- a/NeXt.Vdf-master/NeXt.Vdf.csproj
+++ b/NeXt.Vdf-master/NeXt.Vdf.csproj
@@ -39,7 +39,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CharacterType.cs" />
     <Compile Include="StringRepeatUtils.cs" />
+    <Compile Include="Token.cs" />
+    <Compile Include="TokenType.cs" />
+    <Compile Include="UnexpectedCharacterException.cs" />
+    <Compile Include="VdfDeserializationException.cs" />
     <Compile Include="VdfDeserializer.cs" />
     <Compile Include="VdfDouble.cs" />
     <Compile Include="VdfInteger.cs" />

--- a/NeXt.Vdf-master/Properties/AssemblyInfo.cs
+++ b/NeXt.Vdf-master/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // Allgemeine Informationen über eine Assembly werden über die folgenden 

--- a/NeXt.Vdf-master/StringRepeatUtils.cs
+++ b/NeXt.Vdf-master/StringRepeatUtils.cs
@@ -26,8 +26,8 @@ namespace NeXt.Vdf
             }
             else
             {
-                StringBuilder sb = new StringBuilder();
-                for(int x = 0; x < i ; x++)
+                var sb = new StringBuilder();
+                for(var x = 0; x < i ; x++)
                 {
                     sb.Append(self);
                 }

--- a/NeXt.Vdf-master/Token.cs
+++ b/NeXt.Vdf-master/Token.cs
@@ -1,0 +1,8 @@
+namespace NeXt.Vdf
+{
+    internal struct Token
+    {
+        public TokenType Type;
+        public string Content;
+    }
+}

--- a/NeXt.Vdf-master/TokenType.cs
+++ b/NeXt.Vdf-master/TokenType.cs
@@ -1,0 +1,10 @@
+namespace NeXt.Vdf
+{
+    internal enum TokenType
+    {
+        String,
+        TableStart,
+        TableEnd,
+        Comment
+    }
+}

--- a/NeXt.Vdf-master/UnexpectedCharacterException.cs
+++ b/NeXt.Vdf-master/UnexpectedCharacterException.cs
@@ -1,0 +1,12 @@
+namespace NeXt.Vdf
+{
+    /// <summary>
+    /// A character was unexpected during deserialization
+    /// </summary>
+    public class UnexpectedCharacterException : VdfDeserializationException
+    {
+        public UnexpectedCharacterException(string message, char c) : base($"Unexpected character: {c}. {message}")
+        {
+        }
+    }
+}

--- a/NeXt.Vdf-master/VdfDeserializationException.cs
+++ b/NeXt.Vdf-master/VdfDeserializationException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace NeXt.Vdf
+{
+    /// <summary>
+    /// Base class for al Deserialization exceptions
+    /// </summary>
+    public class VdfDeserializationException : Exception
+    {
+        public VdfDeserializationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/NeXt.Vdf-master/VdfDouble.cs
+++ b/NeXt.Vdf-master/VdfDouble.cs
@@ -1,26 +1,17 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace NeXt.Vdf
+﻿namespace NeXt.Vdf
 {
-
     /// <summary>
     /// A VdfValue that represents a double
     /// </summary>
     public sealed class VdfDouble : VdfValue
     {
-        public VdfDouble(string name) : base(name)
-        {
-            Type = VdfValueType.Double;
-        }
+        public override VdfValueType Type => VdfValueType.Double;
 
-        public VdfDouble(string name, double value) : this(name)
+        public VdfDouble(string name, double value) : base(name)
         {
             Content = value;
         }
 
-        public double Content { get; set; }
+        public double Content { get; }
     }
 }

--- a/NeXt.Vdf-master/VdfInteger.cs
+++ b/NeXt.Vdf-master/VdfInteger.cs
@@ -5,16 +5,12 @@
     /// </summary>
     public sealed class VdfInteger : VdfValue
     {
-        public VdfInteger(string name) : base(name)
-        {
-            Type = VdfValueType.Integer;
-        }
-
-        public VdfInteger(string name, int value) : this(name)
+        public VdfInteger(string name, int value) : base(name)
         {
             Content = value;
         }
 
-        public int Content { get; set; }
+        public int Content { get; }
+        public override VdfValueType Type => VdfValueType.Integer;
     }
 }

--- a/NeXt.Vdf-master/VdfSerializer.cs
+++ b/NeXt.Vdf-master/VdfSerializer.cs
@@ -16,7 +16,7 @@ namespace NeXt.Vdf
         /// <param name="value">the VdfValue to serialize</param>
         public VdfSerializer(VdfValue value)
         {
-            root = value;
+            _root = value;
         }
 
         private const string Newline = "\r\n";
@@ -24,18 +24,18 @@ namespace NeXt.Vdf
         private const string CommentDelimiter = "//";
         private const string TableOpen = "{";
         private const string TableClose = "}";
-        private const string KVSeperator = "\t";
+        private const string KvSeperator = "\t";
         private string IndentString
         {
             get
             {
-                return "\t".Repeat(indentLevel);
+                return "\t".Repeat(_indentLevel);
             }
         }
 
 
-        private VdfValue root;
-        private int indentLevel = 0;
+        private VdfValue _root;
+        private int _indentLevel;
 
         private string EscapeString(string v)
         {
@@ -75,7 +75,7 @@ namespace NeXt.Vdf
             {
                 case VdfValueType.String:
                 {
-                    onStep(KVSeperator);
+                    onStep(KvSeperator);
                     WriteString(onStep, (current as VdfString).Content, true);
   
                     onStep(Newline);
@@ -83,7 +83,7 @@ namespace NeXt.Vdf
                 }
                 case VdfValueType.Integer:
                 {
-                    onStep(KVSeperator);
+                    onStep(KvSeperator);
                     WriteString(onStep, (current as VdfInteger).Content.ToString(CultureInfo.InvariantCulture), false);
 
                     onStep(Newline);
@@ -91,7 +91,7 @@ namespace NeXt.Vdf
                 }
                 case VdfValueType.Double:
                 {
-                    onStep(KVSeperator);
+                    onStep(KvSeperator);
                     WriteString(onStep, (current as VdfDouble).Content.ToString(CultureInfo.InvariantCulture), false);
                     onStep(Newline);
                     break;
@@ -103,12 +103,12 @@ namespace NeXt.Vdf
                     onStep(IndentString);
                     onStep(TableOpen);
                     onStep(Newline);
-                    indentLevel++;
+                    _indentLevel++;
                     foreach(var v in current as VdfTable)
                     {
                         RunSerialization(onStep, v);
                     }
-                    indentLevel--;
+                    _indentLevel--;
                     onStep(IndentString);
                     onStep(TableClose);
                     onStep(Newline);
@@ -123,8 +123,8 @@ namespace NeXt.Vdf
         /// <returns>a string representing the VdfValue</returns>
         public string Serialize()
         {
-            StringBuilder sb = new StringBuilder();
-            RunSerialization((s) => sb.Append(s), root);
+            var sb = new StringBuilder();
+            RunSerialization((s) => sb.Append(s), _root);
 
             return sb.ToString();
         }
@@ -145,9 +145,9 @@ namespace NeXt.Vdf
         /// <param name="encoding"></param>
         public void Serialize(string filePath, Encoding encoding)
         {
-            using(StreamWriter writer = new StreamWriter(filePath, false, encoding))       
+            using(var writer = new StreamWriter(filePath, false, encoding))       
             {
-                RunSerialization(writer.Write, root);
+                RunSerialization(writer.Write, _root);
                 writer.Flush();
             }            
         }

--- a/NeXt.Vdf-master/VdfString.cs
+++ b/NeXt.Vdf-master/VdfString.cs
@@ -5,16 +5,12 @@
     /// </summary>
     public sealed class VdfString : VdfValue
     {
-        public VdfString(string name) : base(name)
-        {
-            Type = VdfValueType.String;
-        }
-
-        public VdfString(string name, string value) : this(name)
+        public VdfString(string name, string value) : base(name)
         {
             Content = value;
         }
 
         public string Content { get; set; }
+        public override VdfValueType Type => VdfValueType.String;
     }
 }

--- a/NeXt.Vdf-master/VdfTable.cs
+++ b/NeXt.Vdf-master/VdfTable.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System;
 
 namespace NeXt.Vdf
@@ -9,128 +8,70 @@ namespace NeXt.Vdf
     /// </summary>
     public sealed class VdfTable : VdfValue, IList<VdfValue>
     {
-        public VdfTable(string name) : base(name) { }
-
-        public VdfTable(string name, IEnumerable<VdfValue> values) : this(name)
+        public VdfTable(string name) : base(name)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
-
-            foreach(var val in values)
-            {
-                Add(val);
-            }
         }
 
-        private List<VdfValue> values = new List<VdfValue>();
-        private Dictionary<string, VdfValue> valuelookup = new Dictionary<string,VdfValue>();
+        private readonly List<VdfValue> _values = new List<VdfValue>();
+        private readonly Dictionary<string, VdfValue> _valuelookup = new Dictionary<string, VdfValue>();
 
         public int IndexOf(VdfValue item)
         {
-            return values.IndexOf(item);
+            return _values.IndexOf(item);
         }
 
         public void Insert(int index, VdfValue item)
         {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
 
-            if(item == null)
+            if (index < 0 || index >= _values.Count)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
-            if(index < 0 || index >= values.Count)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
-            if(string.IsNullOrEmpty(item.Name))
+
+            if (string.IsNullOrEmpty(item.Name))
             {
                 throw new ArgumentException("item name cannot be empty or null");
             }
-            if (ContainsName(item.Name))
+
+            if (TryGetValue(item.Name, out _))
             {
-                throw new ArgumentException("a value with name " + item.Name + " already exists in the table");
+                throw new ArgumentException($"a value with name {item.Name} already exists in the table");
             }
 
 
             item.Parent = this;
 
-            values.Insert(index, item);
-            valuelookup.Add(item.Name, item);
-        }
-
-        public void InsertAfter(VdfValue item, VdfValue newitem)
-        {
-            if(!Contains(item))
-            {
-                throw new ArgumentException("item needs to exist in this table", "item");
-            }
-
-            if (string.IsNullOrEmpty(newitem.Name))
-            {
-                throw new ArgumentException("newitem name cannot be empty or null");
-            }
-            if (ContainsName(newitem.Name))
-            {
-                throw new ArgumentException("a value with name " + newitem.Name + " already exists in the table");
-            }
-
-            int i = -1;
-            for(i = 0; i < values.Count; i++)
-            {
-                if(values[i] == item)
-                {
-                    break;
-                }
-            }
-
-            if(i >= 0 && i < values.Count)
-            {
-                if(i == values.Count -1)
-                {
-                    Add(newitem);
-                }
-                else
-                {
-                    Insert(i + 1, newitem);
-                }
-            }
+            _values.Insert(index, item);
+            _valuelookup.Add(item.Name, item);
         }
 
         public void RemoveAt(int index)
         {
-            var val = values[index];
-            values.RemoveAt(index);
-            valuelookup.Remove(val.Name);
-            
+            var val = _values[index];
+            _values.RemoveAt(index);
+            _valuelookup.Remove(val.Name);
         }
 
         public VdfValue this[int index]
         {
-            get
-            {
-                return values[index];
-            }
+            get => _values[index];
             set
             {
-                if(values[index].Name != value.Name)
+                if (_values[index].Name != value.Name)
                 {
-                    valuelookup.Remove(values[index].Name);
-                    valuelookup.Add(value.Name, value);
+                    _valuelookup.Remove(_values[index].Name);
+                    _valuelookup.Add(value.Name, value);
                 }
                 else
                 {
-                valuelookup[value.Name] = value;
+                    _valuelookup[value.Name] = value;
                 }
-                values[index] = value;
-            }
-        }
 
-        public VdfValue this[string name]
-        {
-            get
-            {
-                return valuelookup[name];
+                _values[index] = value;
             }
         }
 
@@ -138,145 +79,97 @@ namespace NeXt.Vdf
         {
             if (item == null)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
             }
+
             if (string.IsNullOrEmpty(item.Name))
             {
                 throw new ArgumentException("item name cannot be empty or null");
             }
-            if (ContainsName(item.Name))
+
+            if (TryGetValue(item.Name, out _))
             {
-                throw new ArgumentException("a value with name " + item.Name + " already exists in the table");
+                throw new ArgumentException($"a value with name {item.Name} already exists in the table");
             }
-            
+
             item.Parent = this;
 
-            values.Add(item);
-            valuelookup.Add(item.Name, item);
+            _values.Add(item);
+            _valuelookup.Add(item.Name, item);
         }
 
         public void Clear()
         {
-            values.Clear();
-            valuelookup.Clear();
+            _values.Clear();
+            _valuelookup.Clear();
         }
 
         public bool Contains(VdfValue item)
         {
             if (item == null)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
             }
+
             if (string.IsNullOrEmpty(item.Name))
             {
                 throw new ArgumentException("item name cannot be empty or null");
             }
 
-            return valuelookup.ContainsKey(item.Name) && (valuelookup[item.Name] == item);
+            return _valuelookup.TryGetValue(item.Name, out var value) && value == item;
         }
-        
-        public bool ContainsName(string name)
-        {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("name cannot be empty");
-            }
 
-            return valuelookup.ContainsKey(name);
+        public bool TryGetValue(string key, out VdfValue value)
+        {
+            return _valuelookup.TryGetValue(key, out value);
         }
 
         public VdfValue GetByName(string name)
         {
-            if(ContainsName(name))
-            {
-                return valuelookup[name];
-            }
-            return null;
+            return _valuelookup.TryGetValue(name, out var value) ? value : null;
         }
 
         public void CopyTo(VdfValue[] array, int arrayIndex)
         {
-            values.CopyTo(array, arrayIndex);
+            _values.CopyTo(array, arrayIndex);
         }
 
-        public int Count
-        {
-            get { return values.Count; }
-        }
+        public int Count => _values.Count;
 
         public bool Remove(VdfValue item)
         {
             if (item == null)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
             }
+
             if (string.IsNullOrEmpty(item.Name))
             {
                 throw new ArgumentException("item name cannot be empty or null");
             }
-            if(Contains(item))
+
+            if (!Contains(item))
             {
-                valuelookup.Remove(item.Name);
-                values.Remove(item);
-                return true;
+                return false;
             }
-            return false;
+
+            _valuelookup.Remove(item.Name);
+            _values.Remove(item);
+            return true;
         }
 
         public IEnumerator<VdfValue> GetEnumerator()
         {
-            return values.GetEnumerator();
+            return _values.GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            return values.GetEnumerator();
+            return _values.GetEnumerator();
         }
 
-        bool ICollection<VdfValue>.IsReadOnly
-        {
-            get { return false; }
-        }
+        bool ICollection<VdfValue>.IsReadOnly => false;
 
-        public void Traverse(Func<VdfValue, bool> call)
-        {
-            if (call == null)
-            {
-                throw new ArgumentNullException("call");
-            }
-            foreach (var value in values)
-            {
-                if (!call(value))
-                {
-                    break;
-                }
-            }
-        }
-
-        public void TraverseRecursive(Func<VdfValue, bool> call)
-        {
-            if (call == null)
-            {
-                throw new ArgumentNullException("call");
-            }
-            foreach (var value in values)
-            {
-                if (value is VdfTable)
-                {
-                    ((VdfTable)value).TraverseRecursive(call);
-                }
-                else
-                {
-                    if (!call(value))
-                    {
-                        break;
-                    }
-                }
-            }
-        }
+        public override VdfValueType Type => VdfValueType.Table;
     }
 }

--- a/NeXt.Vdf-master/VdfValue.cs
+++ b/NeXt.Vdf-master/VdfValue.cs
@@ -11,23 +11,26 @@ namespace NeXt.Vdf
         {
             Name = name;
         }
-        
+
         /// <summary>
         /// This values name
         /// </summary>
         public string Name { get; private set; }
 
-        private List<string> comments = new List<string>();
+        private List<string> _comments = new List<string>();
 
         /// <summary>
         /// This values type, determines how it can be casted
         /// </summary>
-        public VdfValueType Type { get; protected set; }
+        public abstract VdfValueType Type { get; }
 
         /// <summary>
         /// Comments that where in front of this VdfValue
         /// </summary>
-        public ICollection<string> Comments { get { return comments; } }
+        public ICollection<string> Comments
+        {
+            get { return _comments; }
+        }
 
         /// <summary>
         /// This values Parent, null for root 

--- a/WoxSteam/AppInfo.cs
+++ b/WoxSteam/AppInfo.cs
@@ -1,20 +1,20 @@
+using Newtonsoft.Json;
 using WoxSteam.BinaryVdf;
 
 namespace WoxSteam
 {
+    [JsonObject]
     public class AppInfo
     {
-        public string ClientIcon { get; }
-
-        private AppInfo(BinaryVdfItem value)
-        {
-            var item = value["appinfo"]["common"];
-            ClientIcon = item.GetString("clienticon");
-        }
+        public string ClientIcon { get; set; }
 
         public static AppInfo From(BinaryVdfItem value)
         {
-            return new AppInfo(value);
+            var item = value["appinfo"]["common"];
+            return new AppInfo
+            {
+                ClientIcon = item.GetString("clienticon")
+            };
         }
     }
 }

--- a/WoxSteam/AppInfo.cs
+++ b/WoxSteam/AppInfo.cs
@@ -1,0 +1,20 @@
+using WoxSteam.BinaryVdf;
+
+namespace WoxSteam
+{
+    public class AppInfo
+    {
+        public string ClientIcon { get; }
+
+        private AppInfo(BinaryVdfItem value)
+        {
+            var item = value["appinfo"]["common"];
+            ClientIcon = item.GetString("clienticon");
+        }
+
+        public static AppInfo From(BinaryVdfItem value)
+        {
+            return new AppInfo(value);
+        }
+    }
+}

--- a/WoxSteam/BinaryVdf/BinaryVdfItem.cs
+++ b/WoxSteam/BinaryVdf/BinaryVdfItem.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace WoxSteam.BinaryVdf
+{
+    public class BinaryVdfItem
+    {
+        private readonly Dictionary<string, BinaryVdfItem> _items = new Dictionary<string, BinaryVdfItem>();
+        private readonly string _value;
+
+        public BinaryVdfItem()
+        {
+        }
+
+        public BinaryVdfItem(string value)
+        {
+            _value = value;
+        }
+
+        public BinaryVdfItem this[string index]
+        {
+            get => _items.TryGetValue(index, out var value) ? value : new BinaryVdfItem();
+            set => _items[index] = value;
+        }
+
+        public string GetString(string index)
+        {
+            return this[index]._value;
+        }
+    }
+}

--- a/WoxSteam/BinaryVdf/Reader.cs
+++ b/WoxSteam/BinaryVdf/Reader.cs
@@ -4,128 +4,89 @@ using System.IO;
 
 namespace WoxSteam.BinaryVdf
 {
-	/// <summary>
-	/// Reader for binary vdf files.
-	/// </summary>
-	public class Reader
-	{
-		private readonly BinaryReader reader;
+    /// <summary>
+    /// Reader for binary vdf files.
+    /// </summary>
+    public class Reader
+    {
+        private readonly BinaryReader _reader;
 
-		public Dictionary<uint, BinaryVdfItem> Items = new Dictionary<uint, BinaryVdfItem>();
+        public readonly Dictionary<uint, BinaryVdfItem> Items = new Dictionary<uint, BinaryVdfItem>();
 
-		public Reader(string path)
-		{
-			reader = new BinaryReader(File.OpenRead(path), System.Text.Encoding.UTF8);
+        public Reader(string path)
+        {
+            _reader = new BinaryReader(File.OpenRead(path), System.Text.Encoding.UTF8);
 
-			// Read some header fields
-			reader.ReadByte();
-			if (reader.ReadByte() != 0x44 ||
-			    reader.ReadByte() != 0x56)
-			{
-				throw new Exception("Invalid vdf format");
-			}
+            // Read some header fields
+            _reader.ReadByte();
+            if (_reader.ReadByte() != 0x44 ||
+                _reader.ReadByte() != 0x56)
+            {
+                throw new Exception("Invalid vdf format");
+            }
 
-			// Skip more header fields
-			reader.ReadBytes(5);
+            // Skip more header fields
+            _reader.ReadBytes(5);
 
-			while (true)
-			{
-				var id = reader.ReadUInt32();
-				if (id == 0) break;
+            while (true)
+            {
+                var id = _reader.ReadUInt32();
+                if (id == 0) break;
 
-				// Skip unused fields
-				reader.ReadBytes(44);
+                // Skip unused fields
+                _reader.ReadBytes(44);
 
-				// Load details
-				Items[id] = ReadEntries();
-			}
-		}
+                // Load details
+                Items[id] = ReadEntries();
+            }
+        }
 
-		private BinaryVdfItem ReadEntries()
-		{
-			var result = new BinaryVdfItem();
+        private BinaryVdfItem ReadEntries()
+        {
+            var result = new BinaryVdfItem();
 
-			while (true)
-			{
-				var type = reader.ReadByte();
-				if (type == 0x08) break;
+            while (true)
+            {
+                var type = _reader.ReadByte();
+                if (type == 0x08) break;
 
-				var key = ReadString();
+                var key = ReadString();
 
-				switch (type)
-				{
-					case 0x00:
-						result[key] = ReadEntries();
-						break;
-					case 0x01:
-						result[key] = new BinaryVdfItem(ReadString());
-						break;
-					case 0x02:
-						result[key] = new BinaryVdfItem(reader.ReadUInt32().ToString());
-						break;
-					default:
-						throw new Exception("Uknown entry type " + type + ".");
-				}
-			}
+                switch (type)
+                {
+                    case 0x00:
+                        result[key] = ReadEntries();
+                        break;
+                    case 0x01:
+                        result[key] = new BinaryVdfItem(ReadString());
+                        break;
+                    case 0x02:
+                        result[key] = new BinaryVdfItem(_reader.ReadUInt32().ToString());
+                        break;
+                    default:
+                        throw new Exception("Uknown entry type " + type + ".");
+                }
+            }
 
-			return result;
-		}
+            return result;
+        }
 
-		private string ReadString()
-		{
+        private string ReadString()
+        {
             var result = new List<byte>();
 
-            while (reader.ReadByte() != 0x00)
+            byte b;
+            while ((b = _reader.ReadByte()) != 0x00)
             {
-                reader.BaseStream.Position -= 1;
-                byte b = reader.ReadByte();
                 result.Add(b);
             }
 
-            string yourText = System.Text.Encoding.UTF8.GetString(result.ToArray());
+            return System.Text.Encoding.UTF8.GetString(result.ToArray());
+        }
 
-            return yourText;
-		}
-
-
-	}
-
-	public class BinaryVdfItem
-	{
-		public Dictionary<string, BinaryVdfItem> Items = new Dictionary<string, BinaryVdfItem>();
-		public string Value;
-
-		public BinaryVdfItem()
-		{
-			
-		}
-
-		public BinaryVdfItem(string value)
-		{
-			Value = value;
-		}
-
-		public BinaryVdfItem this[string index]
-		{
-			get
-            {
-                if (Items.ContainsKey(index)) {
-                    return Items[index];
-
-                } else
-                {
-                    return new BinaryVdfItem();
-
-                }
-
-            }
-			set { Items[index] = value; }
-		}
-
-		public string GetString(string index)
-		{
-			return this[index].Value;
-		}
-	}
-
+        public static Dictionary<uint, BinaryVdfItem> Read(string path)
+        {
+            return new Reader(path).Items;
+        }
+    }
 }

--- a/WoxSteam/Game.cs
+++ b/WoxSteam/Game.cs
@@ -1,74 +1,76 @@
 ﻿using System.IO;
 using System.Net;
 using NeXt.Vdf;
-using WoxSteam.BinaryVdf;
-using VdfInteger = NeXt.Vdf.VdfInteger;
-using VdfString = NeXt.Vdf.VdfString;
 
 namespace WoxSteam
 {
-	/// <summary>
-	/// Represents single installed game and its details.
-	/// </summary>
-	public class Game
-	{
-		/// <summary>
-		/// Contains informations stored in app manifest file.
-		/// </summary>
-		private readonly VdfTable manifest;
-		/// <summary>
-		/// Path where resources, like icons, should be stored when downloaded.
-		/// </summary>
-		private readonly string resourcesPath;
+    /// <summary>
+    /// Represents single installed game and its details.
+    /// </summary>
+    public class Game
+    {
+        private const string IconUrl = "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}";
 
-		/// <summary>
-		/// Application id. Used to identify game on steam.
-		/// </summary>
-		public int Appid => ((VdfInteger) manifest.GetByName("appid")).Content;
+        /// <summary>
+        /// Contains informations stored in app manifest file.
+        /// </summary>
+        private readonly VdfTable _manifest;
 
-		/// <summary>
-		/// Game name.
-		/// </summary>
-		public string Name => ((VdfString) manifest.GetByName("name")).Content;
+        /// <summary>
+        /// Path where resources, like icons, should be stored when downloaded.
+        /// </summary>
+        private readonly string _resourcesPath;
 
-		/// <summary>
-		/// Path to game icon. If the icon isn't already downloaded, it will be downloaded upon requesting this.
-		/// </summary>
-		public string Icon => LoadIcon();
+        private static readonly WebClient WebClient = new WebClient();
 
-		/// <summary>
-		/// Game details loaded from appinfo.vdf
-		/// </summary>
-		public BinaryVdfItem Details { get; set; }
+        /// <summary>
+        /// Application id. Used to identify game on steam.
+        /// </summary>
+        public int Appid => ((VdfInteger) _manifest.GetByName("appid")).Content;
 
-		public Game(string pathToManifest, string resourcesPath)
-		{
-			manifest = (VdfTable) VdfDeserializer.FromFile(pathToManifest).Deserialize();
-			this.resourcesPath = resourcesPath;
-		}
+        /// <summary>
+        /// Game name.
+        /// </summary>
+        public string Name => ((VdfString) _manifest.GetByName("name")).Content;
 
-		/// <summary>
-		/// Downloads game icon if present and not already downloaded.
-		/// </summary>
-		/// <returns>local path to cached game icon</returns>
-		private string LoadIcon()
-		{
-			if (Details == null) return null;
-            if (Details.GetString("clienticon") == null) return null;
-			var icon = Details.GetString("clienticon") + ".ico";
-			var cachePath = Path.Combine(resourcesPath, icon);
+        /// <summary>
+        /// Path to game icon. If the icon isn't already downloaded, it will be downloaded upon requesting this.
+        /// </summary>
+        public string Icon => LoadIcon();
 
-			if (File.Exists(cachePath)) return cachePath;
+        /// <summary>
+        /// Game details loaded from appinfo.vdf
+        /// </summary>
+        public AppInfo Details { get; set; }
 
-			using (var client = new WebClient())
-			{
-				client.DownloadFile(
-					$"https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{Appid}/{icon}",
-					cachePath
-				);
-			}
+        public Game(string pathToManifest, string resourcesPath)
+        {
+            _manifest = (VdfTable) VdfDeserializer.FromFile(pathToManifest).Deserialize();
+            _resourcesPath = resourcesPath;
+        }
 
-			return cachePath;
-		}
-	}
+        /// <summary>
+        /// Downloads game icon if present and not already downloaded.
+        /// </summary>
+        /// <returns>local path to cached game icon</returns>
+        private string LoadIcon()
+        {
+            var clientIcon = Details?.ClientIcon;
+            if (clientIcon == null)
+            {
+                return null;
+            }
+
+            var icon = $"{clientIcon}.ico";
+            var cachePath = Path.Combine(_resourcesPath, icon);
+
+            if (File.Exists(cachePath))
+            {
+                return cachePath;
+            }
+
+            WebClient.DownloadFile(string.Format(IconUrl, Appid, icon), cachePath);
+            return cachePath;
+        }
+    }
 }

--- a/WoxSteam/Library.cs
+++ b/WoxSteam/Library.cs
@@ -17,23 +17,23 @@ namespace WoxSteam
 		/// <summary>
 		/// Path to this library.
 		/// </summary>
-		private readonly string path;
+		private readonly string _path;
 		/// <summary>
 		/// Reference to parent steam helper.
 		/// </summary>
-		private readonly Steam steam;
+		private readonly Steam _steam;
 
 		/// <param name="parent">Builder of this library</param>
 		/// <param name="path">Path to library</param>
 		public Library(Steam parent, string path)
 		{
-			this.path = path;
-			steam = parent;
+			_path = path;
+			_steam = parent;
 		}
 
 		public override string ToString()
 		{
-			return "Library(" + path + ")";
+			return "Library(" + _path + ")";
 		}
 
 		/// <summary>
@@ -42,13 +42,13 @@ namespace WoxSteam
 		/// <returns>games installed in this library</returns>
 		public IEnumerable<Game> GetGames()
 		{
-			var dir = new DirectoryInfo(Path.Combine(path, "steamapps"));
+			var dir = new DirectoryInfo(Path.Combine(_path, "steamapps"));
 
 			foreach (var fileInfo in dir.GetFiles())
 			{
 				if (AppMetaRegex.IsMatch(fileInfo.Name))
 				{
-					yield return new Game(fileInfo.FullName, steam.CachePath);
+					yield return new Game(fileInfo.FullName, _steam.CachePath);
 				}
 			}
 		}

--- a/WoxSteam/Main.cs
+++ b/WoxSteam/Main.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Controls;
@@ -9,74 +8,74 @@ namespace WoxSteam
 {
     public class Main : IPlugin, ISettingProvider
     {
-		/// <summary>
-		/// Steam helper library.
-		/// </summary>
-		public Steam Steam { get; private set; }
+        /// <summary>
+        /// Steam helper library.
+        /// </summary>
+        public Steam Steam { get; private set; }
 
-		/// <summary>
-		/// Contains plugin options.
-		/// </summary>
-		public Options Options { get; set; }
+        /// <summary>
+        /// Contains plugin options.
+        /// </summary>
+        public Options Options { get; set; }
 
-		/// <summary>
-		/// Called when users enters some input
-		/// </summary>
-		/// <param name="query"></param>
-		/// <returns></returns>
-	    public List<Result> Query(Query query)
-	    {
-		    return Steam.Games
-			    .Where(game => game.Name.ToLower().Contains(query.RawQuery.ToLower()))
-				.Select(game => new Result()
-			    {
-				    Title = game.Name,
-					SubTitle = "Steam application",
-					IcoPath = game.Icon,
-					Score = 100,
-					Action = context =>
-					{
-						System.Diagnostics.Process.Start(Path.Combine(Steam.RootPath, "steam.exe"), "-applaunch " + game.Appid);
-						return true;
-					}
-			    })
-				.ToList();
-	    }
+        /// <summary>
+        /// Called when users enters some input
+        /// </summary>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public List<Result> Query(Query query)
+        {
+            return Steam.Games
+                .Where(game => game.Name.ToLower().Contains(query.RawQuery.ToLower()))
+                .Select(game => new Result
+                {
+                    Title = game.Name,
+                    SubTitle = "Steam application",
+                    IcoPath = game.Icon,
+                    Score = 100,
+                    Action = context =>
+                    {
+                        System.Diagnostics.Process.Start(Path.Combine(Steam.RootPath, "steam.exe"), "-applaunch " + game.Appid);
+                        return true;
+                    }
+                })
+                .ToList();
+        }
 
-		/// <summary>
-		/// Called to initialize the plugin.
-		/// </summary>
-		/// <param name="context"></param>
-	    public void Init(PluginInitContext context)
-	    {
-			// Create steam library helper
-			// Use plugin directory if possible
-		    Steam = new Steam
-		    {
-			    CachePath = context != null ? Path.Combine(context.CurrentPluginMetadata.PluginDirectory, "Cache") : "Cache"
-		    };
+        /// <summary>
+        /// Called to initialize the plugin.
+        /// </summary>
+        /// <param name="context"></param>
+        public void Init(PluginInitContext context)
+        {
+            // Create steam library helper
+            // Use plugin directory if possible
+            Steam = new Steam
+            {
+                CachePath = context != null ? Path.Combine(context.CurrentPluginMetadata.PluginDirectory, "Cache") : "Cache"
+            };
 
-			// Load options
-		    Options = new Options(context != null ? Path.Combine(context.CurrentPluginMetadata.PluginDirectory, "options.json") : "options.json");
-			Options.Load();
+            // Load options
+            Options = new Options(context != null ? Path.Combine(context.CurrentPluginMetadata.PluginDirectory, "options.json") : "options.json");
+            Options.Load();
 
-			// Apply steam path option if somewhat correct
-		    if (Options.SteamPath != null && Directory.Exists(Options.SteamPath))
-		    {
-			    Steam.RootPath = Options.SteamPath;
-		    }
+            // Apply steam path option if somewhat correct
+            if (Options.SteamPath != null && Directory.Exists(Options.SteamPath))
+            {
+                Steam.RootPath = Options.SteamPath;
+            }
 
-		    // Loads game list
-		    Steam.Load();
+            // Loads game list
+            Steam.Load();
 
-			// Update options value, no matter the source
-		    Options.SteamPath = Steam.RootPath;
-			Options.Save();
-	    }
+            // Update options value, no matter the source
+            Options.SteamPath = Steam.RootPath;
+            Options.Save();
+        }
 
-	    public Control CreateSettingPanel()
-	    {
-		    return new SettingsControl(Options);
-	    }
+        public Control CreateSettingPanel()
+        {
+            return new SettingsControl(Options);
+        }
     }
 }

--- a/WoxSteam/Options.cs
+++ b/WoxSteam/Options.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 using Newtonsoft.Json;
 
 namespace WoxSteam
@@ -13,14 +8,14 @@ namespace WoxSteam
 	/// </summary>
 	public class Options
 	{
-		private readonly string filePath;
+		private readonly string _filePath;
 
 		[JsonProperty]
 		public string SteamPath { get; set; }
 
 		public Options(string path)
 		{
-			filePath = path;
+			_filePath = path;
 		}
 
 		/// <summary>
@@ -29,10 +24,10 @@ namespace WoxSteam
 		public void Load()
 		{
 			// Skip loading if nothing was saved
-			if (!File.Exists(filePath)) return;
+			if (!File.Exists(_filePath)) return;
 
 			// Load stored options
-			var loaded = JsonConvert.DeserializeObject<Options>(File.ReadAllText(filePath));
+			var loaded = JsonConvert.DeserializeObject<Options>(File.ReadAllText(_filePath));
 
 			// Save them here
 			SteamPath = loaded.SteamPath;
@@ -43,7 +38,7 @@ namespace WoxSteam
 		/// </summary>
 		public void Save()
 		{
-			File.WriteAllText(filePath, JsonConvert.SerializeObject(this));
+			File.WriteAllText(_filePath, JsonConvert.SerializeObject(this));
 		}
 	}
 }

--- a/WoxSteam/Properties/AssemblyInfo.cs
+++ b/WoxSteam/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/WoxSteam/SettingsControl.xaml
+++ b/WoxSteam/SettingsControl.xaml
@@ -2,14 +2,13 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:WoxSteam"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
-        <Label x:Name="label" Content="Path to steam:" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="82"/>
+        <Label Content="Path to steam:" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="82"/>
         <TextBox x:Name="SteamPathText" Height="23" Margin="97,12,48,0" TextWrapping="Wrap" Text="C:\Something" VerticalAlignment="Top" TextChanged="SteamPathText_TextChanged"/>
-        <Button x:Name="PickPath" Content="..." HorizontalAlignment="Right" Margin="0,12,10,0" VerticalAlignment="Top" Width="33" Height="23" Click="PickPath_Click"/>
+        <Button Content="..." HorizontalAlignment="Right" Margin="0,12,10,0" VerticalAlignment="Top" Width="33" Height="23" Click="PickPath_Click"/>
 
     </Grid>
 </UserControl>

--- a/WoxSteam/SettingsControl.xaml.cs
+++ b/WoxSteam/SettingsControl.xaml.cs
@@ -2,23 +2,22 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
-using UserControl = System.Windows.Controls.UserControl;
 
 namespace WoxSteam
 {
 	/// <summary>
 	/// Interaction logic for SettingsControl.xaml
 	/// </summary>
-	public partial class SettingsControl : UserControl
+	public partial class SettingsControl
 	{
-		public Options Options;
+		private readonly Options _options;
 
 		public SettingsControl(Options current)
 		{
 			InitializeComponent();
 
-			Options = current;
-			SteamPathText.Text = Options.SteamPath ?? "";
+			_options = current;
+			SteamPathText.Text = _options.SteamPath ?? "";
 		}
 
 		private void PickPath_Click(object sender, RoutedEventArgs e)
@@ -27,14 +26,14 @@ namespace WoxSteam
 			var fd = new FolderBrowserDialog
 			{
 				Description = "Select path to Steam installation folder",
-				SelectedPath = Options.SteamPath
+				SelectedPath = _options.SteamPath
 			};
 
 			// Stop if dialog was cancelled
 			if (fd.ShowDialog() != DialogResult.OK) return;
 
 			// Save selected path
-			SteamPathText.Text = Options.SteamPath = fd.SelectedPath;
+			SteamPathText.Text = _options.SteamPath = fd.SelectedPath;
 		}
 
 		private void SteamPathText_TextChanged(object sender, TextChangedEventArgs e)
@@ -42,8 +41,8 @@ namespace WoxSteam
 			// Only update options on valid paths
 			if (!Directory.Exists(SteamPathText.Text)) return;
 
-			Options.SteamPath = SteamPathText.Text;
-			Options.Save();
+			_options.SteamPath = SteamPathText.Text;
+			_options.Save();
 		}
 	}
 }

--- a/WoxSteam/Steam.cs
+++ b/WoxSteam/Steam.cs
@@ -36,11 +36,6 @@ namespace WoxSteam
         public List<Game> Games { get; } = new List<Game>();
 
         /// <summary>
-        /// Details about games indexed by their appid.
-        /// </summary>
-        public Dictionary<uint, AppInfo> AppInfo { get; private set; }
-
-        /// <summary>
         /// Loads list of installed games.
         /// </summary>
         public void Load()
@@ -52,16 +47,14 @@ namespace WoxSteam
             }
 
             // Load basic list of games
-            if (RootPath == null) LoadPath();
+            if (RootPath == null)
+            {
+                LoadPath();
+            }
+
             LoadLibraries();
             LoadGames();
-
-            // Try to load games details from appinfo
-            LoadAppinfo();
             LoadGamesDetails();
-
-            // No need for app info anymore, free some memory
-            AppInfo = null;
         }
 
         /// <summary>
@@ -69,19 +62,13 @@ namespace WoxSteam
         /// </summary>
         private void LoadGamesDetails()
         {
+            var appinfo = LoadAppinfo();
             foreach (var game in Games)
             {
-                try
+                var id = (uint) game.Appid;
+                if (appinfo.TryGetValue(id, out var item))
                 {
-                    var id = (uint) game.Appid;
-                    if (AppInfo != null && AppInfo.TryGetValue(id, out var item))
-                    {
-                        game.Details = item;
-                    }
-                }
-                catch (Exception)
-                {
-                    game.Details = null;
+                    game.Details = item;
                 }
             }
         }
@@ -123,42 +110,35 @@ namespace WoxSteam
         /// <summary>
         /// Tries to games details from steam appinfo.vdf file.
         /// </summary>
-        private void LoadAppinfo()
+        private Dictionary<uint, AppInfo> LoadAppinfo()
         {
-            try
+            // Basic appinfo file informations
+            var appinfoPath = Path.Combine(RootPath, "appcache", "appinfo.vdf");
+            var currentHash = Md5(appinfoPath);
+
+            // Appinfo is cached to speedup loading
+            var cache = Path.Combine(CachePath, "appinfo.json");
+            var cacheHashFile = Path.Combine(CachePath, "appinfo.vdf.md5");
+            string cacheHash = null;
+
+            // Hash is used to determine if appinfo recently changed
+            if (File.Exists(cacheHashFile))
             {
-                // Basic appinfo file informations
-                var appinfoPath = Path.Combine(RootPath, "appcache", "appinfo.vdf");
-                var currentHash = Md5(appinfoPath);
-
-                // Appinfo is cached to speedup loading
-                var cache = Path.Combine(CachePath, "appinfo.json");
-                var cacheHashFile = Path.Combine(CachePath, "appinfo.vdf.md5");
-                string cacheHash = null;
-
-                // Hash is used to determine if appinfo recently changed
-                if (File.Exists(cacheHashFile))
-                {
-                    cacheHash = File.ReadAllText(cacheHashFile);
-                }
-
-                if (!File.Exists(cache) || cacheHash != null && cacheHash != currentHash)
-                {
-                    AppInfo = Reader.Read(appinfoPath).ToDictionary(pair => pair.Key, pair => WoxSteam.AppInfo.From(pair.Value));
-                    var text = JsonConvert.SerializeObject(AppInfo);
-                    File.WriteAllText(cache, text);
-                    File.WriteAllText(cacheHashFile, currentHash);
-                }
-                else
-                {
-                    var text = File.ReadAllText(cache);
-                    AppInfo = JsonConvert.DeserializeObject<Dictionary<uint, AppInfo>>(text);
-                }
+                cacheHash = File.ReadAllText(cacheHashFile);
             }
-            catch (Exception)
+
+            if (!File.Exists(cache) || cacheHash != null && cacheHash != currentHash)
             {
-                // Failed to load appinfo, but we can still display games, so deploy dummy appinfo
-                AppInfo = null;
+                var apps = Reader.Read(appinfoPath).ToDictionary(pair => pair.Key, pair => AppInfo.From(pair.Value));
+                var text = JsonConvert.SerializeObject(apps);
+                File.WriteAllText(cache, text);
+                File.WriteAllText(cacheHashFile, currentHash);
+                return apps;
+            }
+            else
+            {
+                var text = File.ReadAllText(cache);
+                return JsonConvert.DeserializeObject<Dictionary<uint, AppInfo>>(text);
             }
         }
 
@@ -168,11 +148,14 @@ namespace WoxSteam
         private void LoadLibraries()
         {
             Libraries.Clear();
-
             Libraries.Add(new Library(this, RootPath));
 
             var librariesPath = Path.Combine(RootPath, "steamapps", "libraryfolders.vdf");
-            if (!File.Exists(librariesPath)) return;
+
+            if (!File.Exists(librariesPath))
+            {
+                return;
+            }
 
             var folders = (VdfTable) VdfDeserializer.FromFile(librariesPath).Deserialize();
             var index = 1;

--- a/WoxSteam/Steam.cs
+++ b/WoxSteam/Steam.cs
@@ -71,6 +71,8 @@ namespace WoxSteam
                     game.Details = item;
                 }
             }
+
+            appinfo.Clear();
         }
 
         /// <summary>

--- a/WoxSteam/Steam.cs
+++ b/WoxSteam/Steam.cs
@@ -10,201 +10,203 @@ using WoxSteam.BinaryVdf;
 
 namespace WoxSteam
 {
-	/// <summary>
-	/// Steam helper class.
-	/// </summary>
-	public class Steam
-	{
-		/// <summary>
-		/// Path used to cache icons and stuff.
-		/// </summary>
-		public string CachePath { get; set; } = "./Cache/";
+    /// <summary>
+    /// Steam helper class.
+    /// </summary>
+    public class Steam
+    {
+        /// <summary>
+        /// Path used to cache icons and stuff.
+        /// </summary>
+        public string CachePath { get; set; } = "./Cache/";
 
-		/// <summary>
-		/// Path to steam installation root.
-		/// </summary>
-		public string RootPath { get; set; }
+        /// <summary>
+        /// Path to steam installation root.
+        /// </summary>
+        public string RootPath { get; set; }
 
-		/// <summary>
-		/// List of all current steam libraries.
-		/// </summary>
-		public List<Library> Libraries { get; } = new List<Library>();
+        /// <summary>
+        /// List of all current steam libraries.
+        /// </summary>
+        public List<Library> Libraries { get; } = new List<Library>();
 
-		/// <summary>
-		/// List of all currently installed games.
-		/// </summary>
-		public List<Game> Games { get; } = new List<Game>();
+        /// <summary>
+        /// List of all currently installed games.
+        /// </summary>
+        public List<Game> Games { get; } = new List<Game>();
 
-		/// <summary>
-		/// Details about games indexed by their appid.
-		/// </summary>
-		public Dictionary<uint, BinaryVdfItem> AppInfo { get; private set; }
+        /// <summary>
+        /// Details about games indexed by their appid.
+        /// </summary>
+        public Dictionary<uint, AppInfo> AppInfo { get; private set; }
 
-		/// <summary>
-		/// Loads list of installed games.
-		/// </summary>
-		public void Load()
-		{
-			// Create cache if needed
-			if (!File.Exists(CachePath))
-			{
-				Directory.CreateDirectory(CachePath);
-			}
+        /// <summary>
+        /// Loads list of installed games.
+        /// </summary>
+        public void Load()
+        {
+            // Create cache if needed
+            if (!File.Exists(CachePath))
+            {
+                Directory.CreateDirectory(CachePath);
+            }
 
-			// Load basic list of games
-			if (RootPath == null) LoadPath();
-			LoadLibraries();
-			LoadGames();
+            // Load basic list of games
+            if (RootPath == null) LoadPath();
+            LoadLibraries();
+            LoadGames();
 
-			// Try to load games details from appinfo
-			LoadAppinfo();
-			LoadGamesDetails();
+            // Try to load games details from appinfo
+            LoadAppinfo();
+            LoadGamesDetails();
 
-			// No need for app info anymore, free some memory
-			AppInfo = null;
-		}
+            // No need for app info anymore, free some memory
+            AppInfo = null;
+        }
 
-		/// <summary>
-		/// Tries to assign game details from appinfo to individual games.
-		/// </summary>
-		private void LoadGamesDetails()
-		{
-			foreach (var game in Games)
-			{
-				try
-				{
-					var id = (uint) game.Appid;
-					if (AppInfo != null && AppInfo.ContainsKey(id))
-					{
-						game.Details = AppInfo[id]["appinfo"]["common"];
-					}
-				}
-				catch (Exception)
-				{
-					game.Details = null;
-				}
-			}
-		}
+        /// <summary>
+        /// Tries to assign game details from appinfo to individual games.
+        /// </summary>
+        private void LoadGamesDetails()
+        {
+            foreach (var game in Games)
+            {
+                try
+                {
+                    var id = (uint) game.Appid;
+                    if (AppInfo != null && AppInfo.TryGetValue(id, out var item))
+                    {
+                        game.Details = item;
+                    }
+                }
+                catch (Exception)
+                {
+                    game.Details = null;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Tries to locate steam installation path.
-		/// </summary>
-		private void LoadPath()
-		{
-			var regPath = "SOFTWARE\\Valve\\Steam";
-			RootPath = "C:\\Program Files\\Steam";
+        /// <summary>
+        /// Tries to locate steam installation path.
+        /// </summary>
+        private void LoadPath()
+        {
+            var regPath = "SOFTWARE\\Valve\\Steam";
+            RootPath = "C:\\Program Files\\Steam";
 
-			if (Environment.Is64BitOperatingSystem)
-			{
-				regPath = "SOFTWARE\\Wow6432Node\\Valve\\Steam";
-				RootPath = "C:\\Program Files (x86)\\Steam";
-			}
+            if (Environment.Is64BitOperatingSystem)
+            {
+                regPath = "SOFTWARE\\Wow6432Node\\Valve\\Steam";
+                RootPath = "C:\\Program Files (x86)\\Steam";
+            }
 
-			try
-			{
-				using (var key = Registry.LocalMachine.OpenSubKey(regPath))
-				{
-					var o = key?.GetValue("InstallPath");
-					if (o != null)
-					{
-						RootPath = (string) o;
-					}
-				}
-			}
-			finally
-			{
-				if (!Directory.Exists(RootPath))
-				{
-					throw new Exception("Failed to locate steam installation.");
-				}
-			}
-		}
+            try
+            {
+                using (var key = Registry.LocalMachine.OpenSubKey(regPath))
+                {
+                    var o = key?.GetValue("InstallPath");
+                    if (o != null)
+                    {
+                        RootPath = (string) o;
+                    }
+                }
+            }
+            finally
+            {
+                if (!Directory.Exists(RootPath))
+                {
+                    throw new Exception("Failed to locate steam installation.");
+                }
+            }
+        }
 
-		/// <summary>
-		/// Tries to games details from steam appinfo.vdf file.
-		/// </summary>
-		private void LoadAppinfo()
-		{
-			try
-			{
-				// Basic appinfo file informations
-				var appinfoPath = Path.Combine(RootPath, "appcache", "appinfo.vdf");
-				var currentHash = Md5(appinfoPath);
+        /// <summary>
+        /// Tries to games details from steam appinfo.vdf file.
+        /// </summary>
+        private void LoadAppinfo()
+        {
+            try
+            {
+                // Basic appinfo file informations
+                var appinfoPath = Path.Combine(RootPath, "appcache", "appinfo.vdf");
+                var currentHash = Md5(appinfoPath);
 
-				// Appinfo is cached to speedup loading
-				var cache = Path.Combine(CachePath, "appinfo.json");
-				var cacheHashFile = Path.Combine(CachePath, "appinfo.vdf.md5");
-				string cacheHash = null;
+                // Appinfo is cached to speedup loading
+                var cache = Path.Combine(CachePath, "appinfo.json");
+                var cacheHashFile = Path.Combine(CachePath, "appinfo.vdf.md5");
+                string cacheHash = null;
 
-				// Hash is used to determine if appinfo recently changed
-				if (File.Exists(cacheHashFile))
-				{
-					cacheHash = File.ReadAllText(cacheHashFile);
-				}
+                // Hash is used to determine if appinfo recently changed
+                if (File.Exists(cacheHashFile))
+                {
+                    cacheHash = File.ReadAllText(cacheHashFile);
+                }
 
-				if (!File.Exists(cache) || (cacheHash != null && cacheHash != currentHash))
-				{
-					AppInfo = new Reader(appinfoPath).Items;
-					File.WriteAllText(cache, JsonConvert.SerializeObject(AppInfo));
-					File.WriteAllText(cacheHashFile, currentHash);
-				}
-				else
-				{
-					AppInfo = JsonConvert.DeserializeObject<Dictionary<uint, BinaryVdfItem>>(File.ReadAllText(cache));
-				}
-			}
-			catch (Exception e)
-			{
-				// Failed to load appinfo, but we can still display games, so deploy dummy appinfo
-				AppInfo = null;
-			}
-		}
+                if (!File.Exists(cache) || cacheHash != null && cacheHash != currentHash)
+                {
+                    AppInfo = Reader.Read(appinfoPath).ToDictionary(pair => pair.Key, pair => WoxSteam.AppInfo.From(pair.Value));
+                    var text = JsonConvert.SerializeObject(AppInfo);
+                    File.WriteAllText(cache, text);
+                    File.WriteAllText(cacheHashFile, currentHash);
+                }
+                else
+                {
+                    var text = File.ReadAllText(cache);
+                    AppInfo = JsonConvert.DeserializeObject<Dictionary<uint, AppInfo>>(text);
+                }
+            }
+            catch (Exception)
+            {
+                // Failed to load appinfo, but we can still display games, so deploy dummy appinfo
+                AppInfo = null;
+            }
+        }
 
-		/// <summary>
-		/// Loads paths to all user steam libraries.
-		/// </summary>
-		private void LoadLibraries()
-		{
-			Libraries.Clear();
+        /// <summary>
+        /// Loads paths to all user steam libraries.
+        /// </summary>
+        private void LoadLibraries()
+        {
+            Libraries.Clear();
 
-			Libraries.Add(new Library(this, RootPath));
+            Libraries.Add(new Library(this, RootPath));
 
-			var librariesPath = Path.Combine(RootPath, "steamapps", "libraryfolders.vdf");
-			if (!File.Exists(librariesPath)) return;
+            var librariesPath = Path.Combine(RootPath, "steamapps", "libraryfolders.vdf");
+            if (!File.Exists(librariesPath)) return;
 
-			var folders = (VdfTable) VdfDeserializer.FromFile(librariesPath).Deserialize();
-			var index = 1;
-			while (folders.ContainsName(index.ToString()))
-			{
-				Libraries.Add(new Library(this, ((VdfString) folders.GetByName(index.ToString())).Content));
-				index++;
-			}
-		}
+            var folders = (VdfTable) VdfDeserializer.FromFile(librariesPath).Deserialize();
+            var index = 1;
+            while (folders.TryGetValue(index.ToString(), out var value))
+            {
+                Libraries.Add(new Library(this, ((VdfString) value).Content));
+                index++;
+            }
+        }
 
-		/// <summary>
-		/// Loads list of installed games.
-		/// </summary>
-		private void LoadGames()
-		{
-			Games.Clear();
+        /// <summary>
+        /// Loads list of installed games.
+        /// </summary>
+        private void LoadGames()
+        {
+            Games.Clear();
 
-			foreach (var lib in Libraries)
-			{
-				Games.AddRange(lib.GetGames().ToList());
-			}
-		}
+            foreach (var lib in Libraries)
+            {
+                Games.AddRange(lib.GetGames().ToList());
+            }
+        }
 
-		/// <summary>
-		/// Helper function generating MD5 hash of file.
-		/// </summary>
-		/// <param name="file">path to file</param>
-		/// <returns>md5 hash of file</returns>
-		private static string Md5(string file)
-		{
-			using (var stream = File.OpenRead(file))
-			{
-				return BitConverter.ToString(new MD5Cng().ComputeHash(stream)).Replace("-", string.Empty);
-			}
-		}
-	}
+        /// <summary>
+        /// Helper function generating MD5 hash of file.
+        /// </summary>
+        /// <param name="file">path to file</param>
+        /// <returns>md5 hash of file</returns>
+        private static string Md5(string file)
+        {
+            using (var stream = File.OpenRead(file))
+            {
+                return BitConverter.ToString(new MD5Cng().ComputeHash(stream)).Replace("-", string.Empty);
+            }
+        }
+    }
 }

--- a/WoxSteam/WoxSteam.csproj
+++ b/WoxSteam/WoxSteam.csproj
@@ -54,6 +54,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppInfo.cs" />
+    <Compile Include="BinaryVdf\BinaryVdfItem.cs" />
     <Compile Include="BinaryVdf\Reader.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Game.cs" />


### PR DESCRIPTION
Plugin start time was over 3000ms for me (SSD) and this brings it down to about 400ms when reading from cache.

This changes caching mechanism and AppInfo access by converting BinaryVdfItem from AppInfo to an AppInfo object and using that object for caching and in Game class.
From what I observed AppInfo was only being used for getting the icon so the object only contains an Icon property now.

This also contains a lot of refactoring and under the hood changes I did compulsively. 
Examples:
- Changes suggested by IDE (Rider)
- Using `dictionary.TryGetValue(key, out var value)` instead of combination of `dictionary.ContainsKey(key)` and `dictionary[key]`
- Naming convention change such as `_fieldName` for fields
- Wrapping single line `if`s in brackets
- Language version related changes such as
  - Declaring out variables inside the parameter (`out var a` instead of `var a` and `out a`)
  - Null propagation
- Multiple classes in the same file splitted into separate files

~~**There is one major change that cause problems that I forgot to revert**
Icons weren't loading for me so I thought maybe LoadAppinfo throws an exception so I removed the try..catch but I didn't add it back.
So **I don't recommend this go into production without try..catch re-added**.~~
Re-added try..catch block