### PR TITLE
Fixes empty/corrupt game acfs crashing the plugin

### DIFF
--- a/WoxSteam/Library.cs
+++ b/WoxSteam/Library.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -44,11 +45,19 @@ namespace WoxSteam
 		{
 			var dir = new DirectoryInfo(Path.Combine(path, "steamapps"));
 
-			foreach (var fileInfo in dir.GetFiles())
+			foreach (FileInfo fileInfo in dir.GetFiles())
 			{
 				if (AppMetaRegex.IsMatch(fileInfo.Name))
 				{
-					yield return new Game(fileInfo.FullName, steam.CachePath);
+					Game game = null;
+					try
+					{
+						game = new Game(fileInfo.FullName, steam.CachePath);
+					}
+					catch (Exception) { } // There can be empty/corrupt library files. Ignore these.
+
+					if (game != null)
+						yield return game;
 				}
 			}
 		}


### PR DESCRIPTION
After installing the plugin today i noticed a bug.
I had some empty .acf files in one of my steamapps folders; these were seemingly left over from uninstalled games and caused exceptions during initialization.
I fixed this by catching all exceptions thrown by the Game constructor and ignoring these games.

While there might be a more optimal fix for the bug i experienced, this also fixes all possible issue related to corrupt or invalid .acf files.